### PR TITLE
Fixed font path for windows

### DIFF
--- a/src/rulesets.js
+++ b/src/rulesets.js
@@ -95,7 +95,7 @@ const createFontFaceSrcProperty = (iconFont, options) => {
   const fontPath = path.relative(
     path.resolve(options.publishPath, options.stylesheetPath),
     path.join(options.outputPath, iconFont.fontName)
-  );
+  ).replace(/\\/g, path.posix.sep);
 
   const srcFormats = [];
 


### PR DESCRIPTION
Windows 環境で実行すると fontPath に `\` が適用されてしまい、
参照が上手くいかない状態になりました。
PRを適用頂けると幸いです。