### PR TITLE
[wip] Two steps font build

### DIFF
--- a/src/createFontFaceSrc.js
+++ b/src/createFontFaceSrc.js
@@ -1,7 +1,8 @@
+const path              = require('path');
 const stringTemplate    = require('string-template');
 
 // Templates src property by font type
-module.export = {
+const srcPropertyTemplates = {
 
   eotIE: 'url(\'{fontPath}.eot{fontHash}\')',
   eot: 'url(\'{fontPath}.eot{fontHash}#iefix\') format(\'embedded-opentype\')',

--- a/src/createFontFaceSrc.js
+++ b/src/createFontFaceSrc.js
@@ -1,0 +1,90 @@
+const stringTemplate    = require('string-template');
+
+// Templates src property by font type
+module.export = {
+
+  eotIE: 'url(\'{fontPath}.eot{fontHash}\')',
+  eot: 'url(\'{fontPath}.eot{fontHash}#iefix\') format(\'embedded-opentype\')',
+  woff2: 'url(\'{fontPath}.woff2{fontHash}\') format(\'woff2\')',
+  woff: 'url(\'{fontPath}.woff{fontHash}\') format(\'woff\')',
+  ttf: 'url(\'{fontPath}.ttf{fontHash}\') format(\'truetype\')',
+  svg: 'url(\'{fontPath}.svg{fontHash}#${fontName}\') format(\'svg\')',
+
+};
+
+/**
+ * Get template font hash string.
+ *
+ * @param {string} fontHash use fontHash
+ */
+const getTemplateFontHash = (fontHash) => {
+
+  return fontHash ? `?${fontHash}` : '';
+
+};
+
+
+
+/**
+ * Creates font-face src property.
+ *
+ * @param {object} iconFont icon font properties.
+ * @param {object} options  options of generating fonts.
+ * @returns {string} font-face src property.
+ */
+exports.createFontFaceSrcProperty = (iconFont, options) => {
+
+  // Creates font path
+  const fontPath = path.relative(
+    path.resolve(options.publishPath, options.stylesheetPath),
+    path.join(options.outputPath, iconFont.fontName)
+  ).replace(/\\/g, path.posix.sep);
+
+  const srcFormats = [];
+
+  // for each formats
+  options.formats.forEach((format) => {
+
+    const template = srcPropertyTemplates[format];
+
+    // Is not empty template?
+    if (template) {
+
+      srcFormats.push(stringTemplate(template, {
+        fontPath,
+        fontHash: getTemplateFontHash(iconFont.fontHash),
+        fontName: iconFont.fontName
+      }));
+
+    }
+
+  });
+
+  // returns src property
+  return srcFormats.join(', ');
+
+};
+
+/**
+ * Creates font-face src property with EOT.
+ *
+ * @param {object} iconFont icon font properties.
+ * @param {object} options  options of generating fonts.
+ * @returns {string} font-face src property.
+ */
+exports.createFontFaceSrcPropertyWithEOT = (iconFont, options) => {
+
+  // Creates font path
+  const fontPath = path.relative(
+    path.resolve(options.publishPath, options.stylesheetPath),
+    path.join(options.outputPath, iconFont.fontName)
+  );
+
+  // returns src property
+  return stringTemplate(srcPropertyTemplates.eotIE, {
+    fontPath,
+    fontHash: getTemplateFontHash(iconFont.fontHash),
+    fontName: iconFont.fontName
+  });
+
+};

--- a/src/createFonts.js
+++ b/src/createFonts.js
@@ -1,0 +1,62 @@
+const fontGenerator     = require('./font_generator');
+
+/**
+ * Creates icon fonts.
+ *
+ * @param {object} iconFont   icon font options.
+ * @param {object} rulesets   Rulesets of PostCSS object.
+ * @param {object} options    web font options.
+ * @returns {Promise} returns glyphs when successed.
+ */
+module.exports = (iconFont, rulesets, options) => {
+
+  // Empty font src?
+  if (!iconFont.src) {
+
+    // noop
+    return Promise.resolve();
+
+  }
+
+  const files   = [].concat(glob.sync(iconFont.src));
+
+  // Empty files?
+  if (files.length === 0) {
+
+    // noop
+    return Promise.resolve();
+
+  }
+
+  return new Promise((resolve, reject) => {
+
+    fontGenerator({
+      files,
+      dest: path.resolve(options.outputPath),
+      cachePath: options.cachePath,
+      fontOptions: {
+        formats: options.formats,
+        fontName: iconFont.fontName,
+        fontHeight: options.fontHeight,
+        ascent: options.ascent,
+        descent: options.descent,
+        normalize: options.normalize,
+        centerHorizontally: options.centerHorizontally,
+        fixedWidth: options.fixedWidth,
+        fixedHash: options.fixedHash,
+        startUnicode: options.startUnicode,
+        prependUnicode: options.prependUnicode,
+      }
+    }).then((glyphs) => {
+
+      resolve(glyphs);
+
+    }).catch((error) => {
+
+      reject(error);
+
+    });
+
+  });
+
+};

--- a/src/createFonts.js
+++ b/src/createFonts.js
@@ -1,3 +1,5 @@
+const path              = require('path');
+const glob              = require('glob');
 const fontGenerator     = require('./font_generator');
 
 /**

--- a/src/createWebFontRuleSets.js
+++ b/src/createWebFontRuleSets.js
@@ -1,0 +1,133 @@
+const {
+  createFontFaceSrcProperty,
+  createFontFaceSrcPropertyWithEOT
+} = require('./createFontFaceSrc');
+
+
+/**
+ * Creates rulesets of web font.
+ *
+ * @param {string}  iconFont    target icon font.
+ * @param {object}  rulesets    Rulesets of PostCSS object.
+ * @param {object}  glyphs      glyphs of web font.
+ * @param {object}  options     generating font options.
+ */
+module.exports = (iconFont, rulesets, glyphs, options) => {
+
+  // inserts new src property
+  rulesets.fontFaceRule.insertAfter(iconFont.srcDecl, postcss.decl({
+    prop: 'src',
+    value: createFontFaceSrcProperty(iconFont, options)
+  }));
+
+  // No contains eot format?
+  if (options.formats.indexOf('eot') === -1) {
+
+    // Remove src property
+    iconFont.srcDecl.remove();
+
+  } else {
+
+    // Replace src property
+    iconFont.srcDecl.replaceWith({
+      prop: 'src',
+      value: createFontFaceSrcPropertyWithEOT(iconFont, options)
+    });
+
+  }
+
+  // creates class prefix names
+  const useClassNamePrefix = options.classNamePrefix ? `${options.classNamePrefix}-` : '';
+  const useClassNamePrefixBefore = options.classNamePrefixBefore ? `${options.classNamePrefixBefore}-` : '';
+  const useClassNamePrefixAfter = options.classNamePrefixAfter ? `${options.classNamePrefixAfter}-` : '';
+
+  // append base ruleset
+  const iconRule = postcss.rule({
+    selectors: [
+      `[class^='${useClassNamePrefix}${iconFont.fontName}-']::before`,
+      `[class*=' ${useClassNamePrefix}${iconFont.fontName}-']::before`,
+      `[class^='${useClassNamePrefix}${useClassNamePrefixBefore}${iconFont.fontName}-']::before`,
+      `[class*=' ${useClassNamePrefix}${useClassNamePrefixBefore}${iconFont.fontName}-']::before`,
+      `[class^='${useClassNamePrefix}${useClassNamePrefixAfter}${iconFont.fontName}-']::after`,
+      `[class*=' ${useClassNamePrefix}${useClassNamePrefixAfter}${iconFont.fontName}-']::after`,
+    ]
+  });
+  iconRule.append({
+    prop: 'font-family',
+    value: `'${iconFont.fontName}', sans-serif`
+  },
+  {
+    prop: 'font-style',
+    value: 'normal'
+  },
+  {
+    prop: 'font-weight',
+    value: 'normal'
+  },
+  {
+    prop: 'font-variant',
+    value: 'normal'
+  },
+  {
+    prop: 'text-transform',
+    value: 'none'
+  },
+  {
+    prop: 'line-height',
+    value: '1'
+  },
+  {
+    prop: 'vertical-align',
+    value: `${options.verticalAlign}`
+  },
+  {
+    prop: '-webkit-font-smoothing',
+    value: 'antialiased'
+  },
+  {
+    prop: '-moz-osx-font-smoothing',
+    value: 'grayscale'
+  }
+  );
+  rulesets.root.insertAfter(rulesets.fontFaceRule, iconRule);
+
+
+  let baseRule = iconRule;
+
+  // append glyphs
+  glyphs.forEach((glyph) => {
+
+    [
+      {
+        prefix: useClassNamePrefix,
+        pseudo: 'before',
+      },
+      {
+        prefix: `${useClassNamePrefix}${useClassNamePrefixBefore}`,
+        pseudo: 'before',
+      },
+      {
+        prefix: `${useClassNamePrefix}${useClassNamePrefixAfter}`,
+        pseudo: 'after',
+      },
+    ].forEach((classNamingConvention) => {
+
+      const fontRule = postcss.rule({
+        selector: `.${classNamingConvention.prefix}${iconFont.fontName}-${glyph.name}::${classNamingConvention.pseudo}`,
+      });
+      fontRule.append({
+        prop: 'content',
+        value: `'\\${glyph.codepoint.toString(16).toUpperCase()}'`
+      });
+
+      // insert ruleset
+      rulesets.root.insertAfter(baseRule, fontRule);
+
+      // replace base ruleset
+      baseRule = fontRule;
+
+    });
+
+  });
+
+};

--- a/src/createWebFontRuleSets.js
+++ b/src/createWebFontRuleSets.js
@@ -1,3 +1,4 @@
+const postcss           = require('postcss');
 const {
   createFontFaceSrcProperty,
   createFontFaceSrcPropertyWithEOT
@@ -117,7 +118,7 @@ module.exports = (iconFont, rulesets, glyphs, options) => {
       });
       fontRule.append({
         prop: 'content',
-        value: `'\\${glyph.codepoint.toString(16).toUpperCase()}'`
+        value: glyph.content
       });
 
       // insert ruleset

--- a/src/css_font_generator.js
+++ b/src/css_font_generator.js
@@ -1,0 +1,57 @@
+const path              = require('path');
+const fontGenerator     = require('./font_generator');
+
+
+/**
+ * Process generating web fonts of rulesets.
+ *
+ * @param {object} root     root of PostCSS.
+ * @param {object} options  options of generating fonts.
+ * @returns {Promise} promise object.
+ */
+module.exports = async(root, options) => {
+  const contents = [];
+
+  root.walkDecls(
+    'content',
+    decl => {
+      if (!options.iconsBaseMatch.match(decl.value)) return;
+
+      contents.push({
+        decl,
+        file: decl.value.replace(/^\s*url\(['"]?([^'")])['"]?\)/, '$1')
+      });
+
+    }
+  );
+
+  if (!contents.length) return;
+
+  const fontResult = await fontGenerator({
+    files: contents.map(({ file }) => file),
+    dest: path.resolve(options.outputPath),
+    cachePath: options.cachePath,
+    fontOptions: {
+      formats: options.formats,
+      fontName: iconFont.fontName,
+      fontHeight: options.fontHeight,
+      ascent: options.ascent,
+      descent: options.descent,
+      normalize: options.normalize,
+      centerHorizontally: options.centerHorizontally,
+      fixedWidth: options.fixedWidth,
+      fixedHash: options.fixedHash,
+      startUnicode: options.startUnicode,
+      prependUnicode: options.prependUnicode,
+    }
+  });
+
+  if (!fontResult) return;
+
+  fontResult.glyphs.forEach(glyph => contents
+    .filter(({ file }) => file === glyph.file)
+    .forEach(({ decl }) => {
+      decl.value = `'\\${glyph.codepoint.toString(16).toUpperCase()}'`;
+    })
+  );
+};

--- a/src/css_font_generator.js
+++ b/src/css_font_generator.js
@@ -15,20 +15,21 @@ module.exports = async(root, options) => {
   root.walkDecls(
     'content',
     decl => {
-      if (!options.iconsBaseMatch.match(decl.value)) return;
+      if (!options.contentIconMatch.exec(decl.value)) return;
 
       contents.push({
         decl,
-        file: decl.value.replace(/^\s*url\(['"]?([^'")])['"]?\)/, '$1')
+        file: decl.value.replace(/^\s*url\(['"]?([^'")])+['"]?\)/, '$1')
       });
 
     }
   );
 
   if (!contents.length) return;
+  const files = Array.from(new Set(contents.map(({ file }) => file)));
 
   const fontResult = await fontGenerator({
-    files: contents.map(({ file }) => file),
+    files,
     dest: path.resolve(options.outputPath),
     cachePath: options.cachePath,
     fontOptions: {

--- a/src/css_font_generator.js
+++ b/src/css_font_generator.js
@@ -19,7 +19,7 @@ module.exports = async(root, options) => {
 
       contents.push({
         decl,
-        file: decl.value.replace(/^\s*url\(['"]?([^'")])+['"]?\)/, '$1')
+        file: decl.value.replace(/^\s*url\(['"]?([^'")]+)['"]?\)/, '$1')
       });
 
     }

--- a/src/css_font_generator.js
+++ b/src/css_font_generator.js
@@ -33,7 +33,7 @@ module.exports = async(root, options) => {
     cachePath: options.cachePath,
     fontOptions: {
       formats: options.formats,
-      fontName: iconFont.fontName,
+      fontName: options.fontName,
       fontHeight: options.fontHeight,
       ascent: options.ascent,
       descent: options.descent,

--- a/src/css_generator.js
+++ b/src/css_generator.js
@@ -9,7 +9,6 @@ const createFonts           = require('./createFonts');
 const createWebFontRuleSets = require('./createWebFontRuleSets');
 
 
-
 /**
  * Parsing font-face rulesets.
  *
@@ -18,9 +17,6 @@ const createWebFontRuleSets = require('./createWebFontRuleSets');
  * @returns {Promise} promise object.
  */
 const processFontFace = (rulesets, options) => {
-
-  return new Promise((resolve, reject) => {
-
     const iconFont = {};
 
     // Get 'font-family' property.
@@ -57,65 +53,19 @@ const processFontFace = (rulesets, options) => {
 
     });
 
-    // creates fonts
-    createFonts(iconFont, rulesets, options).then((fontResult) => {
+    const files   = [].concat(glob.sync(iconFont.src));
 
-      // creates rulesets
-      if (fontResult) {
+    if (!files.length) return void;
 
-        // Select cachebuster time option.
-        if (options.cachebuster !== null && options.cachebuster !== undefined) {
+    const glyphs = files
+      .map(file => ({
+        name: path.basename(file),
+        conent: `url('${file}')`
+      }))
+      .map(options.glyphNormalizer);
 
-          const useCachebuster = options.cachebuster.toString().toLowerCase();
-
-          // Select cachebuster option
-          switch (useCachebuster) {
-
-            // hash cachebuster
-            case 'hash':
-              iconFont.fontHash = fontResult.svgHash;
-              break;
-
-            // fixed cachebuster
-            case 'fixed':
-              iconFont.fontHash = options.cachebusterFixed;
-              break;
-
-            // Disable cachebuster
-            default:
-              iconFont.fontHash = null;
-              break;
-
-          }
-
-        } else {
-
-          // Disable cachebuster
-          iconFont.fontHash = null;
-
-        }
-        const glyphs = fontResult.glyphs.map(glyph => ({
-          name: glyph.name,
-          conent: `'\\${glyph.codepoint.toString(16).toUpperCase()}'`
-        }));
-
-        // creates rulesets
-        createWebFontRuleSets(iconFont, rulesets, glyphs, options);
-
-      }
-
-      // returns successful
-      resolve();
-
-    }).catch((error) => {
-
-      // returns error
-      reject(error);
-
-    });
-
-  });
-
+    // creates rulesets
+    createWebFontRuleSets(iconFont, rulesets, glyphs, options);
 };
 
 

--- a/src/css_generator.js
+++ b/src/css_generator.js
@@ -55,12 +55,12 @@ const processFontFace = (rulesets, options) => {
 
     const files   = [].concat(glob.sync(iconFont.src));
 
-    if (!files.length) return void;
+    if (!files.length) return;
 
     const glyphs = files
       .map(file => ({
-        name: path.basename(file),
-        conent: `url('${file}')`
+        name: path.basename(file, '.svg'),
+        content: `url('${file}')`
       }))
       .map(options.glyphNormalizer);
 

--- a/src/font_generator.js
+++ b/src/font_generator.js
@@ -221,6 +221,7 @@ const FONT_GENERATORS = {
         // append simple glyphs
         simpleGlyphs.push({
           name,
+          file,
           codepoint: currentCodePoint
         });
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@
  */
 const postcss   = require('postcss');
 const rulesets  = require('./rulesets');
+const cssrulesets = require('./css_generator');
+const font_from_rulesets = require('./css_font_generator');
 
 // default options
 const defaultOptions = {
@@ -43,7 +45,23 @@ defaultExport.onlyCss = postcss.plugin('postcss-webfont-css', (options) => {
 
   return (root) => {
 
-    return rulesets(root, usingOptions);
+    return cssrulesets(root, usingOptions);
+
+  };
+
+});
+
+defaultExport.onlyFont = postcss.plugin('postcss-webfont-font', (options) => {
+
+  const usingOptions = Object.assign(
+    { contentIconMatch: /.+\.svg/ },
+    defaultOptions,
+    options
+  );
+
+  return (root) => {
+
+    return font_from_rulesets(root, usingOptions);
 
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,11 @@ const defaultOptions = {
   classNamePrefixAfter: 'after',
   cachebuster: 'hash',
   cachebusterFixed: '',
+  glyphNormalizer: glyph => glyph
 
 };
 
-module.exports = postcss.plugin('postcss-webfont', (options) => {
+const defaultExport = postcss.plugin('postcss-webfont', (options) => {
 
   const usingOptions = Object.assign({}, defaultOptions, options);
 
@@ -35,3 +36,18 @@ module.exports = postcss.plugin('postcss-webfont', (options) => {
   };
 
 });
+
+defaultExport.onlyCss = postcss.plugin('postcss-webfont-css', (options) => {
+
+  const usingOptions = Object.assign({}, defaultOptions, options);
+
+  return (root) => {
+
+    return rulesets(root, usingOptions);
+
+  };
+
+});
+
+
+module.exports = defaultExport;

--- a/src/rulesets.js
+++ b/src/rulesets.js
@@ -3,7 +3,6 @@
  */
 const postcss           = require('postcss');
 const path              = require('path');
-const glob              = require('glob');
 
 const createFonts           = require('./createFonts');
 const createWebFontRuleSets = require('./createWebFontRuleSets');
@@ -94,10 +93,12 @@ const processFontFace = (rulesets, options) => {
           iconFont.fontHash = null;
 
         }
-        const glyphs = fontResult.glyphs.map(glyph => ({
-          name: glyph.name,
-          content: `'\\${glyph.codepoint.toString(16).toUpperCase()}'`
-        }));
+        const glyphs = fontResult.glyphs
+          .map(glyph => ({
+            name: glyph.name,
+            content: `'\\${glyph.codepoint.toString(16).toUpperCase()}'`
+          }))
+          .map(options.glyphNormalizer);
 
         // creates rulesets
         createWebFontRuleSets(iconFont, rulesets, glyphs, options);

--- a/src/rulesets.js
+++ b/src/rulesets.js
@@ -96,7 +96,7 @@ const processFontFace = (rulesets, options) => {
         }
         const glyphs = fontResult.glyphs.map(glyph => ({
           name: glyph.name,
-          conent: `'\\${glyph.codepoint.toString(16).toUpperCase()}'`
+          content: `'\\${glyph.codepoint.toString(16).toUpperCase()}'`
         }));
 
         // creates rulesets


### PR DESCRIPTION
## what:
I tricked it a little bit to make two steps instead of one.

Default behavior keeps working.

## why:


Actual version is the best to build icon font with all icon-set, but my case has only small sub set of icons.

```css
@font-face {
  src: url('/node_modules/third-party/library/*/*.svg');
  font-family: 'onlyMyIcons';
  font-weight: normal;
  font-style: normal;
}
```

```javascript
plugins: [
  webfont.onlyCss({ }), // it makes icon css from your base css

  ...otherPostcssPlugins, // change your css here (ie: with purgeCSS)

  webfont.onlyFont({ fontName: 'onlyMyIcons' }) // it makes fonts only for icons left
]
```

Outputs (in my case) two icons selectors and font with only this two icons.

## todo:
* [ ] test it a lot;
* [ ] update docs.