### PR TITLE
I added CSS vars to use as content

### DIFF
--- a/src/rulesets.js
+++ b/src/rulesets.js
@@ -248,10 +248,21 @@ const createWebFontRuleSets = (iconFont, rulesets, glyphs, options) => {
   rulesets.root.insertAfter(rulesets.fontFaceRule, iconRule);
 
 
-  let baseRule = iconRule;
+ let baseRule = iconRule
+		, vars = postcss.rule({
+		selector: ':root',
+	});
 
   // append glyphs
   glyphs.forEach((glyph) => {
+
+		let glyphVal = glyph.codepoint.toString(16).toUpperCase()
+
+		// add css vars
+		vars = vars.append({
+			prop: `--${iconFont.fontName}-${glyph.name}`,
+			value: `'\\${glyphVal}'`
+		});
 
     [
       {
@@ -273,7 +284,7 @@ const createWebFontRuleSets = (iconFont, rulesets, glyphs, options) => {
       });
       fontRule.append({
         prop: 'content',
-        value: `'\\${glyph.codepoint.toString(16).toUpperCase()}'`
+        value: `'\\${glyphVal}'`
       });
 
       // insert ruleset
@@ -285,6 +296,9 @@ const createWebFontRuleSets = (iconFont, rulesets, glyphs, options) => {
     });
 
   });
+
+	// Insert Vars
+	rulesets.root.insertAfter(baseRule, vars);
 
 };
 


### PR DESCRIPTION
I have made a slight change so that it saves css vars to your stylesheet.

You can use these in scss or css for :after / :before pseudo classes to dynamically set the content.

I did this because i myself had the problem that my webfont would expand all the time and i couldn't use the codepoints provided, because they would change when i added icons.

i know this probably isn't the most perfect solution for the problem. it would probably be better if it would have an option and generate a scss variable file or just straight up use the same codepoints  that have already been processed (i thought that was how the .fontcache.json file worked in the first place)